### PR TITLE
Preserving blob iam roles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='berglas_python',
-      version='0.3.0',
+      version='0.3.1',
       url='https://github.com/guillaumeblaquiere/berglas-python',
       license='Apache 2.0',
       author='Guillaume Blaquiere',


### PR DESCRIPTION
As expected, when berglas-python update the blob content on GCS the permissions are overwritten by the upload process. This PR makes berglas-python act the same way as Berglas does. Updating the permissions when the object is updated.

* Preserving the IAM policy from blob objects while updating them
* ensuring the IAM policy for the blob object will be updated only if the file already exists.
