### PR TITLE
pinning versions to versions compatible with existing code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-google-cloud-storage
-google-cloud-kms
-cryptography
+google-cloud-storage~=1.30.0
+google-cloud-kms~=1.4.0
+cryptography~=3.0


### PR DESCRIPTION
google-cloud-kms v2.0.0 breaks with the current release. This stops the bleeding until the code can be updated to support the newer google-cloud-kms.